### PR TITLE
Upgrade node@20.15.0 & add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+### What's new
+
+[comment]: Add a list with the new features.
+
+### What's fixed
+
+[comment]: Add a list with the fixed things.
+
+### How to test
+
+[comment]: Steps to test the new features or the fixes.
+
+### Breaking changes
+
+[comment]: Explain the breaking changes and how to fix them.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "engines": {
-    "node": ">=20.14.0"
+    "node": ">=20.15.0"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",


### PR DESCRIPTION
### What's new

- New PR template

### What's fixed

- Upgraded `node@20.15.0`

### How to test

### Breaking changes

- Minimum node version now is 20.25.0
