### PR TITLE
[SEC] Fix ReDoS on searchbyname

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -6,6 +6,7 @@ import { promisify } from 'util';
 import User from '../models/userModel';
 import { UserRoles, UserSchemaType, UserType } from '../models/userTypes';
 import catchAsync from '../utils/catchAsync';
+import { escapeRegExp } from '../utils/consts';
 
 type Request = RequestExpress & {
   user?: UserType;
@@ -639,11 +640,14 @@ export const getUserByName = catchAsync(async (req: Request, res: Response) => {
     });
   }
 
+  // Sanitize the name to prevent ReDoS by escaping special characters
+  const sanitizedInput = escapeRegExp(name);
+
   // Calculate the number of users to skip
   const skip = (page - 1) * perpage;
 
   // Use a regular expression for case-insensitive search
-  const nameRegex = new RegExp(name, 'i');
+  const nameRegex = new RegExp(sanitizedInput, 'i');
 
   const users = (await User.find({ name: { $regex: nameRegex } })
     .skip(skip)

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,1 +1,5 @@
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+export const escapeRegExp = (input: string) => {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+};


### PR DESCRIPTION
### What's new

No new features here...

### What's fixed

- On `getUserByName` (`/api/v1/users/searchbyname`) an attacker could do a _ReDoS attack_ by passing special characters to the name to search. Now this input has been sanitized.

### How to test

- Test the `/api/v1/users/searchbyname` endpoint.

### Breaking changes

No breaking changes here...

### Checklist

- [x] I've tested locally the changes
- [x] I've run `yarn verify` to perform basic checks and lints
- [x] I've run `gitleaks` to check for hardcoded secrets and tokens
